### PR TITLE
PHPUnit testing, Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - hhvm
+  - nightly
+
+before_script:
+ - composer install
+
+notifications:
+  email: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         verbose="true"
+         stopOnFailure="false"
+         processIsolation="false"
+         backupGlobals="false"
+         syntaxCheck="true"
+        >
+    <testsuite name="SSOHelper Test Suite">
+        <directory>./tests/SSOHelperTest</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout"/>
+    </logging>
+</phpunit>

--- a/src/SSOHelper.php
+++ b/src/SSOHelper.php
@@ -58,9 +58,7 @@ class SSOHelper {
 			'nonce' => $nonce,
 			'external_id' => $id,
 			'email' => $email
-		);
-
-		$parameters = array_merge($parameters, $extraParameters);
+		) + $extraParameters;
 
 		$payload = base64_encode(http_build_query($parameters));
 

--- a/tests/SSOHelperTest/SSOHelperTest.php
+++ b/tests/SSOHelperTest/SSOHelperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SSOHelperTest;
+
+use Cviebrock\DiscoursePHP\SSOHelper;
+
+class SSOHelperTest extends \PHPUnit_Framework_TestCase {
+
+    const SECRET = 'my_sso_secret';
+    const PAYLOAD = 'bm9uY2U9ZTE4YmRiYTgxOTdhZGUwOTZkOTY0NTdkNDg2NzViYjkmcmV0dXJu%0AX3Nzb191cmw9aHR0cCUzQSUyRiUyRmRpc2NvdXJzZS5iZWF1Y2FsLmNvbSUy%0ARnNlc3Npb24lMkZzc29fbG9naW4%3D%0A';
+    const SIGNATURE = '112119cead5be8305852bdd34536d6fb71ad6fef240be1c486412bcf078f41dd';
+    const NONCE = 'e18bdba8197ade096d96457d48675bb9';
+
+    /**
+     * @var SSOHelper
+     */
+    protected $sso;
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->sso = new SSOHelper;
+        $this->sso->setSecret(self::SECRET);
+    }
+
+    public function testInOut() {
+        $this->assertTrue(
+        $this->sso->validatePayload(self::PAYLOAD, self::SIGNATURE)
+        );
+
+        $userId = 1234;
+        $userEmail = 'sso@example.com';
+        $response = $this->sso->getSignInString(
+        $this->sso->getNonce(self::PAYLOAD), $userId, $userEmail
+        );
+        $expected = 'sso=bm9uY2U9ZTE4YmRiYTgxOTdhZGUwOTZkOTY0'
+        . 'NTdkNDg2NzViYjkmZXh0ZXJuYWxfaWQ9MTIzNCZlbWFpbD1zc2'
+        . '8lNDBleGFtcGxlLmNvbQ%3D%3D&sig=9db5456c6d21b8bad96'
+        . 'a9071edfd0fd87160f7b71687dbbed2050d4c7750b643';
+        $this->assertEquals($expected, $response);
+    }
+
+    public function testNonceGood() {
+        $payload = base64_encode('nonce=1111');
+        $this->assertEquals(1111, $this->sso->getNonce($payload));
+
+        $payload = base64_encode('nonce=2222&asdf=true');
+        $this->assertEquals(2222, $this->sso->getNonce($payload));
+    }
+
+    /**
+     * @expectedException \Cviebrock\DiscoursePHP\Exception\PayloadException
+     */
+    public function testNonceBad1() {
+        $payload = base64_encode('nonc=1111');
+        $this->sso->getNonce($payload);
+    }
+
+    /**
+     * @expectedException \Cviebrock\DiscoursePHP\Exception\PayloadException
+     */
+    public function testNonceBad2() {
+        $this->sso->getNonce('junk');
+    }
+
+    public function testExtraParametersPlayNice() {
+        $userId = 1234;
+        $userEmail = 'sso@example.com';
+        $extraParams = [
+            'external_id' => 'junk',
+            'email' => 'junk',
+            'only_me' => 'gets_through'
+        ];
+        $response = $this->sso->getSignInString(
+        $this->sso->getNonce(self::PAYLOAD), $userId, $userEmail, $extraParams
+        );
+        parse_str($response, $response);
+        $parts = array();
+        parse_str(base64_decode($response['sso']), $parts);
+        $this->assertEquals($userId, $parts['external_id']);
+        $this->assertEquals($userEmail, $parts['email']);
+        $this->assertEquals(self::NONCE, $parts['nonce']);
+        $this->assertEquals('gets_through', $parts['only_me']);
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+foreach (['.', '..', '../../..'] as $dir) {
+    $autoload = "{$dir}/vendor/autoload.php";
+    if (file_exists($autoload)) {
+        include $autoload;
+        return;
+    }
+}
+throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');


### PR DESCRIPTION
- $extraParameters should not have the ability to overwrite given nonce/email/external_id.

Thanks for this class, by the way.   And this is now all ready for Travis CI, I think.

Sincerely,
Derek
